### PR TITLE
Fix incorrect instruction on watching service status

### DIFF
--- a/controlcenter/zenpack_dev.rst
+++ b/controlcenter/zenpack_dev.rst
@@ -76,7 +76,7 @@ to do the following items:
 
 * Watch the services with::
 
-   watch serviced service status
+   zendev serviced service status
 
 *  .. WARNING:: 
       


### PR DESCRIPTION
On my dev environment 'zendev serviced service status' works but 'watch serviced service status' gives me an error: serviced not found. 